### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@
 
 ### Configuration Details
 
-- [Server configuration documentation]('docs/client-server.md')
+- [Server configuration documentation]("docs/client-server.md")
 - [Client configuration documentation]('docs/client-config.md')
 - [Model configuration documentation]('docs/config-models.md')
 

--- a/README.md
+++ b/README.md
@@ -217,16 +217,16 @@
 
 ### Configuration Details
 
-- [Server configuration documentation]("docs/client-server.md")
-- [Client configuration documentation]('docs/client-config.md')
-- [Model configuration documentation]('docs/config-models.md')
+- [Server configuration documentation](/docs/client-server.md)
+- [Client configuration documentation](/docs/client-config.md)
+- [Model configuration documentation](/docs/config-models.md)
 
 Additional nodes:
 
-- [Default models configuration]('docs/models-default.md')
-- [Recommended models configuration]('docs/models-recommended.md')
-- [Model conversion notes]('docs/models-convert.md')
-- [Server API]('docs/api.md')
+- [Default models configuration](/docs/models-default.md)
+- [Recommended models configuration](/docs/models-recommended.md')
+- [Model conversion notes](/docs/models-convert.md)
+- [Server API](/docs/api.md)
 
 
 <br><hr><br>


### PR DESCRIPTION
Fixed the markdown form. The links are going to 404's. Hopefully this helped some!
`https://github.com/vladmandic/pigallery/blob/master/'docs/client-server.md'`
This ^ is wrong because the server is not used to the files having **'**s. This commit should fix that.